### PR TITLE
Editorial Fixes and Terminology Updates

### DIFF
--- a/draft-ietf-tsvwg-sctp-dtls-chunk.md
+++ b/draft-ietf-tsvwg-sctp-dtls-chunk.md
@@ -1650,7 +1650,7 @@ Parameters group:
 
 *  One new SCTP Chunk Parameter Type
 
-*  Three new SCTP Error Cause Codes
+*  Two new SCTP Error Cause Codes
 
 And finally the update of one registered SCTP Payload Protocol
 Identifier.


### PR DESCRIPTION
This patch series includes small editorial improvements to the SCTP-DTLS draft for correctness, terminology consistency with DTLS key management, and readability. No protocol behavior is changed.

It covers:
- Grammar, wording, and typo fixes
- Correcting "cipher suit" -> "cipher suite"
- Aligning terminology with DTLS key management
- Cleaning up DTLS CID references in the abstract API

